### PR TITLE
Lepton veto can now be applied on skimming. Split leptons into muons and electrons.

### DIFF
--- a/analysis/sixBanalysis/config/skim_ntuple_2018_TriggerSFs.cfg
+++ b/analysis/sixBanalysis/config/skim_ntuple_2018_TriggerSFs.cfg
@@ -1,0 +1,96 @@
+# -------------------------------------------------------------------------
+# all the data parameters that are consumed by the code (files, etc)
+[parameters]
+year = 2018
+
+# jet energy resolution smearing
+JERScaleFactorFile = data/jer/2018/Summer19UL18_JRV2_MC_SF_AK4PFchs.txt
+JERResolutionFile  = data/jer/2018/Summer19UL18_JRV2_MC_PtResolution_AK4PFchs.txt
+
+# jet energy scale shift
+JECFileName = data/jec/2018/Summer19UL18_V5_MC_UncertaintySources_AK4PFchs.txt
+
+# pileup reweighting - comment the option to disable reading of PU rew weights (stores dummy 1 values)
+# PUweightFile = data/pileup/test_PUweights_2018.root
+
+# b tag SFs
+DeepJetScaleFactorFile = data/btag/DeepJet_106XUL18SF_WPonly.csv
+
+# -------------------------------------------------------------------------
+# all the swicthes that configure the skim (what to save, how to select things, etc)
+[configurations]
+
+bTagWPDef = 0.0490, 0.2783, 0.7100  # Cuts for WP : Loose, Medium, Tight WPs
+
+saveLeptons = true # save the electron and muon p4
+
+applyMuonVeto = false
+applyMuonSelection = true
+nMuonsCutValue = 1       
+nMuonsCutDirection = ==  # Options: [==, >=, >, <=, <, !=]
+muonIsoCut    = Tight    # Options: [vLoose, Loose, Medium, Tight, vTight, vvTight]
+muonPtCut     = 26.0     # 2 GeV above the HLT threshold of 24 GeV
+muonEtaCut    = 2.4
+muonID        = Loose    # Options: [Loose, Medium, Tight]
+
+applyEleVeto = true
+applyEleSelection = false
+eleID        = Loose  # Options: [Loose, 90, 80]
+elePtCut     = 15.0
+eleEtaCut    = 2.5
+eleIsoCut    = 0.15
+
+saveJetColl = true ## save the jet and genjet collections
+saveShapes  = true ## save the event shape variables
+
+# ttbar : 2 highest DeepJet score
+# sixb  : events containing 6 jets
+skimType = trgeff
+
+nMinBtag  = 0  # minimum number of b tagged jets in the event (>=)
+bTagWP    = 1  # Which WP to apply for the selection above. 0 : Loose, 1: Medium, 2: Tight WP
+
+## -------------------------------------------------------------------------
+## configuration of the various function-specific parameters
+
+[presel]
+apply = true
+pt_min  = 20
+eta_max = 2.5
+pf_id   = 1
+pu_id   = 1
+njetsCutValue = 6
+njetsCutDirection = >=
+
+# Revisit needed here
+[bias_pt_sort]
+applyPreselections = false
+applyJetCuts       = true        # Apply extra jet cuts after preselection
+pt_cuts            = 60,40,40    # ,20,20 # pt cuts for jet selection
+btagWP_cuts        = 1,1,1     # ,0,0 # btagWP cuts for jet selection
+
+## -------------------------------------------------------------------------
+## trigger specific section
+[triggers]
+
+#TriggerFiring
+applyTrigger = true # true/false to apply/not apply trigger bit
+saveDecision = true # true to create branches with individual trigger decisions
+
+#Trigger Matching
+makeORof = trigger1:HLT_IsoMu24, trigger2:HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5, trigger3:HLT_PFHT1050, trigger4:HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59, trigger5:HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94
+
+# MaxDeltaR                   = 0.5
+# trigger1_ObjectRequirements = 1:10:0, 1:5:4, 3:3:0, 1:11:2, 1:12:4, 1:13:1, 1:14:2, 1:15:3, 1:16:4, 3:4:0, 1:17:3
+# MatchWithSelectedObjects    = true
+
+# #TriggerSF
+# TriggerEfficiencyFileName_TriggerMatched    = data/TriggerEfficiency_Fit_2018_matched_0p5.root
+# TriggerEfficiencyFileName_NotTriggerMatched = data/TriggerEfficiency_Fit_2018_notmatched.root
+# UseScaleFactor     = true
+# MatchedScaleFactor = true
+# SimulateTrigger    = true
+# DatasetYear        = 2018
+
+[data]
+lumimask = data/lumi_cert/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt

--- a/analysis/sixBanalysis/config/skim_ntuple_2018_marina.cfg
+++ b/analysis/sixBanalysis/config/skim_ntuple_2018_marina.cfg
@@ -1,0 +1,128 @@
+## -------------------------------------------------------------------------
+## all the data parameters that are consumed by the code (files, etc)
+[parameters]
+year = 2018
+
+# jet energy resolution smearing
+JERScaleFactorFile       = data/jer/Autumn18_V7b_MC_SF_AK4PFchs.txt 
+JERResolutionFile        = data/jer/Autumn18_V7b_MC_PtResolution_AK4PFchs.txt 
+
+# jet energy scale shift
+JECFileName              = data/jec/Autumn18_V19_MC_UncertaintySources_AK4PFchs.txt
+
+# pileup reweighting - comment the option to disable reading of PU rew weights (stores dummy 1 values)
+# PUweightFile              = data/pileup/test_PUweights_2018.root
+
+# b tag SFs
+DeepJetScaleFactorFile    = data/btag/DeepJet_106XUL18SF_WPonly.csv
+
+## -------------------------------------------------------------------------
+## all the swicthes that configure the skim (what to save, how to select things, etc)
+[configurations]
+
+bTagWPDef = 0.0490, 0.2783, 0.7100  # Cuts for WP : Loose, Medium, Tight WPs
+
+saveLeptons = false # save the electron and muon p4
+
+applyMuonVeto = true
+applyMuonSelection = false
+muonIsoCut    = Tight # Options: [vLoose, Loose, Medium, Tight, vTight, vvTight]
+muonPtCut     = 10.0
+muonEtaCut    = 2.4
+muonID        = Loose # Options: [Loose, Medium, Tight]
+
+applyEleVeto = true
+applyEleSelection = false
+eleID        = Loose # Options: [Loose, 90, 80]
+elePtCut     = 15.0
+eleEtaCut    = 2.5
+eleIsoCut    = 0.15
+
+
+saveJetColl = true ## save the jet and genjet collections
+saveShapes  = true ## save the event shape variables
+
+# ttbar : 2 highest DeepJet score
+# sixb  : events containing 6 jets
+skimType = sixb
+
+# choice of 6 jets (for sixb skim only)
+# .- bias_pt_sort : 3 groups by WP  (T, M, L) with pT order within each group
+# .- pt_sort      : 6 highest pT jets
+# .- 6jet_DNN     : use the 6 jet DNN classifier output
+# .- maxbtag      : 6 highest b tagged jets
+# .- 5btag_maxpt  : 5 jets with highest b tag + 1 remaining highest pT jet
+# .- 4btag_maxpt  : 4 jets with highest b tag + 2 remaining highest pT jet
+sixbJetChoice = bias_pt_sort
+
+# how to pair the 6 jets into 3 H (for sixb skim only)
+# .- passthrough   : just a test function, pair them in the order they appear ABCDEF -> (AB)(CD)(EF)
+# .- D_HHH         : minimise distance from a 3D diagonal a la HH->4b nonresonant
+# .- 2jet_DNN      : use the output of the dijet classifier
+# .- min_diag_distance : distance from the 3D diagonal
+jetPairsChoice = D_HHH
+
+# how to determine which H are from Y->HH and which from direct X decay
+# .- passthrough : just a test function, pair them in the order they are returned by the pair function
+# .- leadJetInX  : the H with the leading jet of the 6 jets is HX, the other two are HY1 and HY2
+XYHChoice = leadJetInX
+
+# use regressed pT to build the H p4.
+# NOTE: This is applied in the recomputation of p4(H) *after* the bb jets have been chosen
+useRegressedPtForHp4 = true
+
+nMinBtag  = 0  # minimum number of b tagged jets in the event (>=)
+bTagWP    = 1  # Which WP to apply for the selection above. 0 : Loose, 1: Medium, 2: Tight WP
+
+
+## -------------------------------------------------------------------------
+## configuration of the various function-specific parameters
+
+[presel]
+apply = true
+pt_min  = 20
+eta_max = 2.5
+pf_id   = 1
+pu_id   = 1
+
+[bias_pt_sort]
+applyPreselections = true
+applyJetCuts = true ## apply extra jet cuts after preselection
+pt_cuts = 60,40,40,20 # ,20,20 # pt cuts for jet selection
+btagWP_cuts = 2,2,1,1 # ,0,0 # btagWP cuts for jet selection
+
+[6jet_DNN]
+model_path = models/keras/6jet_classifier/
+
+[2jet_DNN]
+model_path = models/keras/2jet_classifier/
+
+[leadJetInX]
+useRegressedPt = true
+
+## -------------------------------------------------------------------------
+## trigger specific section
+[triggers]
+
+#TriggerFiring
+applyTrigger = true # true/false to apply/not apply trigger bit
+saveDecision = true # true to create branches with individual trigger decisions
+
+#Trigger Matching
+makeORof = trigger1:HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5, trigger2:HLT_PFHT1050, trigger3:HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59, trigger4:HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94
+
+# MaxDeltaR                   = 0.5
+# trigger1_ObjectRequirements = 1:10:0, 1:5:4, 3:3:0, 1:11:2, 1:12:4, 1:13:1, 1:14:2, 1:15:3, 1:16:4, 3:4:0, 1:17:3
+# MatchWithSelectedObjects    = true
+
+# #TriggerSF
+# TriggerEfficiencyFileName_TriggerMatched    = data/TriggerEfficiency_Fit_2018_matched_0p5.root
+# TriggerEfficiencyFileName_NotTriggerMatched = data/TriggerEfficiency_Fit_2018_notmatched.root
+# UseScaleFactor     = true
+# MatchedScaleFactor = true
+# SimulateTrigger    = true
+# DatasetYear        = 2018
+
+
+[data]
+lumimask = data/lumi_cert/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt

--- a/analysis/sixBanalysis/interface/DirectionalCut.h
+++ b/analysis/sixBanalysis/interface/DirectionalCut.h
@@ -1,0 +1,75 @@
+#ifndef DirectionalCut_h
+#define DirectionalCut_h
+
+#include <string>
+#include <cmath>
+#include "CfgParser.h"
+
+template <typename T>
+class DirectionalCut {
+  enum DirectionalCutType {kGT, kGEQ, kLT, kLEQ, kEQ, kNEQ};
+ 
+ public:
+  
+ DirectionalCut(CfgParser &config, const std::string& name)
+   : fValue(config.readFloatOpt(name+std::string("Value"))) {
+    std::string direction = config.readStringOpt(name+std::string("Direction"));
+    if (direction == "EQ" || direction == "==") fCutDirection = kEQ;
+    else if (direction == "NEQ" || direction == "!=") fCutDirection = kNEQ;
+    else if (direction == "GT"  || direction == ">")  fCutDirection = kGT;
+    else if (direction == "GEQ" || direction == ">=") fCutDirection = kGEQ;
+    else if (direction == "LT"  || direction == "<")  fCutDirection = kLT;
+    else if (direction == "LEQ" || direction == "<=") fCutDirection = kLEQ;
+  }
+  
+ DirectionalCut(const std::string direction, const double value)
+   : fValue(value) {
+    if (direction == "EQ" || direction == "==") fCutDirection = kEQ;
+    else if (direction == "NEQ" || direction == "!=") fCutDirection = kNEQ;
+    else if (direction == "GT"  || direction == ">") fCutDirection = kGT;
+    else if (direction == "GEQ" || direction == ">=") fCutDirection = kGEQ;
+    else if (direction == "LT"  || direction == "<") fCutDirection =kLT;
+    else if (direction == "LEQ" || direction == "<=") fCutDirection =kLEQ;
+  }
+  
+  ~DirectionalCut() { }
+  
+  bool passedCut(const T testValue) const 
+  {
+    if (fCutDirection == kEQ)
+      return std::fabs(testValue-fValue) < 0.0001;
+    if (fCutDirection == kNEQ)
+      return std::fabs(testValue-fValue) > 0.0001;
+    if (fCutDirection == kGT)
+      return (testValue > fValue);
+    if (fCutDirection == kGEQ)
+      return (testValue >= fValue);
+    if (fCutDirection == kLT)
+      return (testValue < fValue);
+    if (fCutDirection == kLEQ)
+      return (testValue <= fValue);
+    return false; // never reached
+  }
+  
+  T getCutValue(void) const{ return fValue;}
+  DirectionalCutType getCutDirection(void) const{ return fCutDirection;}
+  std::string getCutValueString(void) const{ return std::to_string(fValue); }
+  std::string getCutDirectionString(void) const{
+    if (fCutDirection == kEQ) return "==";
+    else if (fCutDirection == kNEQ) return "!=";
+    else if (fCutDirection == kGT) return ">";
+    else if (fCutDirection == kGEQ) return ">=";
+    else if (fCutDirection == kLT) return "<";
+    else if (fCutDirection == kLEQ) return "<=";
+    else return "Unknown";
+  }
+  
+ private:
+  T fValue;
+  DirectionalCutType fCutDirection;
+};
+
+#endif
+
+
+

--- a/analysis/sixBanalysis/interface/Skim_functions.h
+++ b/analysis/sixBanalysis/interface/Skim_functions.h
@@ -5,6 +5,8 @@
 #include "EventInfo.h"
 #include "Cutflow.h"
 
+#include "Electron.h"
+#include "Muon.h"
 #include "Jet.h"
 #include "GenJet.h"
 #include "GenPart.h"
@@ -89,9 +91,10 @@ public:
   ////////////////////////////////////////////////////
   /// non-jet functions
   ////////////////////////////////////////////////////
-
-  void select_leptons(NanoAODTree &nat, EventInfo &ei);
-
+  
+  std::vector<Electron> select_electrons(CfgParser &config, NanoAODTree &nat, EventInfo &ei);
+  std::vector<Muon> select_muons(CfgParser &config, NanoAODTree &nat, EventInfo &ei);
+  
   void set_btag_WPs(std::vector<double> btag_wps) { btag_WPs = btag_wps; }
   
   ////////////////////////////////////////////////////

--- a/analysis/sixBanalysis/interface/Skim_functions.h
+++ b/analysis/sixBanalysis/interface/Skim_functions.h
@@ -1,6 +1,7 @@
 #ifndef SKIM_FUNCTIONS_H
 #define SKIM_FUNCTIONS_H
 
+#include "DirectionalCut.h"
 #include "NanoAODTree.h"
 #include "EventInfo.h"
 #include "Cutflow.h"

--- a/analysis/sixBanalysis/interface/TrgEff_functions.h
+++ b/analysis/sixBanalysis/interface/TrgEff_functions.h
@@ -1,0 +1,39 @@
+#ifndef TRGEFF_FUNCTIONS_H
+#define TRGEFF_FUNCTIONS_H
+
+#include "Skim_functions.h"
+
+class TrgEff_functions : public Skim_functions{
+  
+public:
+
+  ////////////////////////////////////////////////////
+  /// Start methods to be overidden
+
+  void Print() override{
+    cout << "[INFO] ... Using TrgEff_functions" << endl; 
+  }
+
+  ////////////////////////////////////////////////////
+  /// parameter initialization
+  ////////////////////////////////////////////////////
+
+  /**
+   * @brief Initialize param values for skim as defined in config file 
+   * This method can be overriden to define skim specific values
+   * Default defines preselection cuts
+   * @param cfgr .cfg config file
+   */
+  void initialize_params_from_cfg(CfgParser &cfgr) override;
+  
+  std::vector<Jet> select_jets(NanoAODTree &nat, EventInfo& ei, const std::vector<Jet> &in_jets);
+  std::vector<Jet> select_jets_bias_pt_sort(NanoAODTree &nat, EventInfo& ei, const std::vector<Jet> &in_jets);
+  
+  //private:
+  
+  // NN evaluators for DNN
+  //std::unique_ptr<EvalNN> n_2j_classifier_;
+  //std::unique_ptr<EvalNN> n_6j_classifier_;
+};
+
+#endif //TRGEFF_FUNCTIONS_H

--- a/analysis/sixBanalysis/src/OutputTree.cc
+++ b/analysis/sixBanalysis/src/OutputTree.cc
@@ -370,7 +370,15 @@ void OutputTree::init_branches(std::map<std::string, bool> branch_switches)
       BRANCH_m_pt_ptRegressed_eta_phi_DeepJet_p4(bjet2);
       if (is_enabled("gen_brs")) tree_->Branch("bjet2_hadflav", &bjet2_hadflav);
     }
-
+  
+  if (is_enabled("trgeff_brs"))
+    {
+      std::cout << "[INFO] OutputTree : enabling TrgEff branches" << std::endl;
+      // marina
+      //tree_->Branch("HT", &HT);
+      //tree_->Branch("HTb", &HTb);
+    }
+  
   tree_->Branch("n_total_jet",&n_total_jet);
   tree_->Branch("n_jet", &n_jet);
 

--- a/analysis/sixBanalysis/src/TrgEff_functions.cc
+++ b/analysis/sixBanalysis/src/TrgEff_functions.cc
@@ -1,0 +1,62 @@
+#include "TrgEff_functions.h"
+#include "Math/VectorUtil.h"
+#include "Math/Vector3D.h"
+#include "Math/Functions.h"
+
+#include <iostream>
+#include <tuple>
+#include <algorithm>
+
+#include "Muon.h"
+
+using namespace std;
+
+void TrgEff_functions::initialize_params_from_cfg(CfgParser& config)
+{
+  // preselections
+  pmap.insert_param<bool>("presel", "apply", config.readBoolOpt("presel::apply"));
+  pmap.insert_param<double>("presel", "pt_min",  config.readDoubleOpt("presel::pt_min"));
+  pmap.insert_param<double>("presel", "eta_max", config.readDoubleOpt("presel::eta_max"));
+  pmap.insert_param<int>   ("presel", "pf_id",   config.readIntOpt("presel::pf_id"));
+  pmap.insert_param<int>   ("presel", "pu_id",   config.readIntOpt("presel::pu_id"));
+  
+  // parse specific parameters for various functions
+  pmap.insert_param<bool>          ("bias_pt_sort", "applyJetCuts", config.readBoolOpt("bias_pt_sort::applyJetCuts"));
+  pmap.insert_param<vector<double>>("bias_pt_sort", "pt_cuts",      config.readDoubleListOpt("bias_pt_sort::pt_cuts"));
+  pmap.insert_param<vector<int>>   ("bias_pt_sort", "btagWP_cuts",  config.readIntListOpt("bias_pt_sort::btagWP_cuts"));
+}
+
+std::vector<Jet> TrgEff_functions::select_jets(NanoAODTree &nat, EventInfo& ei, const std::vector<Jet> &in_jets)
+{
+  return select_jets_bias_pt_sort(nat, ei, in_jets);
+}
+
+std::vector<Jet> TrgEff_functions::select_jets_bias_pt_sort(NanoAODTree &nat, EventInfo& ei, const std::vector<Jet> &in_jets)
+{
+  std::vector<Jet> jets = bias_pt_sort_jets(nat, ei, in_jets);
+  bool apply_cuts = pmap.get_param<bool>("bias_pt_sort", "applyJetCuts");
+  
+  if (apply_cuts)
+    {
+      bool pass_cuts = true;
+      std::vector<double> pt_cuts     = pmap.get_param<std::vector<double>>("bias_pt_sort", "pt_cuts");
+      std::vector<int>    btagWP_cuts = pmap.get_param<std::vector<int>>("bias_pt_sort", "btagWP_cuts");
+      
+      unsigned int ncuts = pt_cuts.size();
+      
+      for (unsigned int icut=0; icut<ncuts; icut++)
+	{
+	  const Jet& j = jets[icut];
+	  double ptCut = pt_cuts[icut];
+	  int  btagWP  = btagWP_cuts[icut];
+	  
+	  if (j.get_pt() <= ptCut || j.get_btag() <= btag_WPs[btagWP])
+	    {
+	      pass_cuts = false;
+	      break;
+	    }
+	}
+      if (!pass_cuts) jets.resize(0);
+    }
+  return jets;
+}


### PR DESCRIPTION
Files with important changes for the lepton veto (or selection):

- test/skim_ntuple.cpp  (You will see many changed lines, many of them are not real changes, just indentation or making the code a bit easier to read) 
- src/Skim_functions.cc
- interface/DirectionalCut.h (new)
- interface/Skim_functions.h
- config/skim_ntuple_2018_maring.cfg (lines 25-39 are related to the leptons) 

Note that some of the hardcoded d_{xy}, d_{z} selections are still there until I find the official recommendations to be used with each ID.
Please change your configs to have the parameters related to electrons and muons (or point me to them so I can change them).

The changes in the following files are not related to the lepton selection (Trigger Efficiency Measurement), so you can ignore them for the moment:

- config/skim_ntuple_2018_TriggerSFs.cfg
- interface/TrgEff_functions.h
- src/TrgEff_functions.cc
- src/OutputTree.cc