### PR TITLE
Skimming: Jets & b-jets cuts on pT

### DIFF
--- a/analysis/sixBanalysis/config/skim_ntuple_2018_TriggerSFs.cfg
+++ b/analysis/sixBanalysis/config/skim_ntuple_2018_TriggerSFs.cfg
@@ -22,23 +22,27 @@ DeepJetScaleFactorFile = data/btag/DeepJet_106XUL18SF_WPonly.csv
 
 bTagWPDef = 0.0490, 0.2783, 0.7100  # Cuts for WP : Loose, Medium, Tight WPs
 
-saveLeptons = true # save the electron and muon p4
+# Muon veto or selection
+applyMuonVeto      = false
+saveMuonColl       = true  # If veto is enabled, this should be false
+applyMuonSelection = true  # If veto is enabled, this should be false
+nMuonsCutValue     = 1     # Only needed when applyMuonSelection is true
+nMuonsCutDirection = ==    # Only needed when applyMuonSelection is true
+muonIsoCut         = Tight # Options: [vLoose, Loose, Medium, Tight, vTight, vvTight]
+muonPtCut          = 26.0
+muonEtaCut         = 2.4
+muonID             = Loose # Options: [Loose, Medium, Tight]     
 
-applyMuonVeto = false
-applyMuonSelection = true
-nMuonsCutValue = 1       
-nMuonsCutDirection = ==  # Options: [==, >=, >, <=, <, !=]
-muonIsoCut    = Tight    # Options: [vLoose, Loose, Medium, Tight, vTight, vvTight]
-muonPtCut     = 26.0     # 2 GeV above the HLT threshold of 24 GeV
-muonEtaCut    = 2.4
-muonID        = Loose    # Options: [Loose, Medium, Tight]
-
-applyEleVeto = true
-applyEleSelection = false
-eleID        = Loose  # Options: [Loose, 90, 80]
-elePtCut     = 15.0
-eleEtaCut    = 2.5
-eleIsoCut    = 0.15
+# Electron muon or selection
+applyEleVeto       = true
+saveEleColl        = true  # If veto is enabled, this should be false
+applyEleSelection  = true  # If veto is enabled, this should be false
+nEleCutValue       = 0     # Only needed when applyEleSelection is true
+nEleCutDirection   = >=    # Only needed when applyEleSelection is true
+eleID              = Loose # Options: [Loose, 90, 80]
+elePtCut           = 15.0
+eleEtaCut          = 2.5
+eleIsoCut          = 0.15
 
 saveJetColl = true ## save the jet and genjet collections
 saveShapes  = true ## save the event shape variables
@@ -55,7 +59,7 @@ bTagWP    = 1  # Which WP to apply for the selection above. 0 : Loose, 1: Medium
 
 [presel]
 apply = true
-pt_min  = 60,40,40,20
+pt_min  = 20
 eta_max = 2.5
 pf_id   = 1
 pu_id   = 1
@@ -66,6 +70,7 @@ njetsCutDirection = >=
 [bias_pt_sort]
 applyPreselections = false
 applyJetCuts       = true      # Apply extra jet cuts after preselection
+pt_cuts            = 60,40,20
 btagWP_cuts        = 1,1,1     # ,0,0 # btagWP cuts for jet selection
 
 ## -------------------------------------------------------------------------

--- a/analysis/sixBanalysis/config/skim_ntuple_2018_TriggerSFs.cfg
+++ b/analysis/sixBanalysis/config/skim_ntuple_2018_TriggerSFs.cfg
@@ -55,7 +55,7 @@ bTagWP    = 1  # Which WP to apply for the selection above. 0 : Loose, 1: Medium
 
 [presel]
 apply = true
-pt_min  = 20
+pt_min  = 60,40,40,20
 eta_max = 2.5
 pf_id   = 1
 pu_id   = 1
@@ -65,8 +65,7 @@ njetsCutDirection = >=
 # Revisit needed here
 [bias_pt_sort]
 applyPreselections = false
-applyJetCuts       = true        # Apply extra jet cuts after preselection
-pt_cuts            = 60,40,40    # ,20,20 # pt cuts for jet selection
+applyJetCuts       = true      # Apply extra jet cuts after preselection
 btagWP_cuts        = 1,1,1     # ,0,0 # btagWP cuts for jet selection
 
 ## -------------------------------------------------------------------------

--- a/analysis/sixBanalysis/config/skim_ntuple_2018_marina.cfg
+++ b/analysis/sixBanalysis/config/skim_ntuple_2018_marina.cfg
@@ -22,22 +22,27 @@ DeepJetScaleFactorFile    = data/btag/DeepJet_106XUL18SF_WPonly.csv
 
 bTagWPDef = 0.0490, 0.2783, 0.7100  # Cuts for WP : Loose, Medium, Tight WPs
 
-saveLeptons = false # save the electron and muon p4
+# Muon veto or selection
+applyMuonVeto      = false
+saveMuonColl       = true  # If veto is enabled, this should be false
+applyMuonSelection = true  # If veto is enabled, this should be false
+nMuonsCutValue     = 0     # Only needed when applyMuonSelection is true
+nMuonsCutDirection = >=    # Only needed when applyMuonSelection is true
+muonIsoCut         = Tight # Options: [vLoose, Loose, Medium, Tight, vTight, vvTight]
+muonPtCut          = 10.0
+muonEtaCut         = 2.4
+muonID             = Loose # Options: [Loose, Medium, Tight]
 
-applyMuonVeto = true
-applyMuonSelection = false
-muonIsoCut    = Tight # Options: [vLoose, Loose, Medium, Tight, vTight, vvTight]
-muonPtCut     = 10.0
-muonEtaCut    = 2.4
-muonID        = Loose # Options: [Loose, Medium, Tight]
-
-applyEleVeto = true
-applyEleSelection = false
-eleID        = Loose # Options: [Loose, 90, 80]
-elePtCut     = 15.0
-eleEtaCut    = 2.5
-eleIsoCut    = 0.15
-
+# Electron muon or selection
+applyEleVeto       = false
+saveEleColl        = true  # If veto is enabled, this should be false
+applyEleSelection  = true  # If veto is enabled, this should be false
+nEleCutValue       = 0     # Only needed when applyEleSelection is true
+nEleCutDirection   = >=    # Only needed when applyEleSelection is true
+eleID              = Loose # Options: [Loose, 90, 80]
+elePtCut           = 15.0
+eleEtaCut          = 2.5
+eleIsoCut          = 0.15
 
 saveJetColl = true ## save the jet and genjet collections
 saveShapes  = true ## save the event shape variables

--- a/analysis/sixBanalysis/config/skim_ntuple_2018_marina.cfg
+++ b/analysis/sixBanalysis/config/skim_ntuple_2018_marina.cfg
@@ -84,11 +84,14 @@ pt_min  = 20
 eta_max = 2.5
 pf_id   = 1
 pu_id   = 1
+njetsCutValue = 6
+njetsCutDirection = >=
+
 
 [bias_pt_sort]
 applyPreselections = true
 applyJetCuts = true ## apply extra jet cuts after preselection
-pt_cuts = 60,40,40,20 # ,20,20 # pt cuts for jet selection
+#pt_cuts = 60,40,40,20 # ,20,20 # pt cuts for jet selection
 btagWP_cuts = 2,2,1,1 # ,0,0 # btagWP cuts for jet selection
 
 [6jet_DNN]

--- a/analysis/sixBanalysis/config/skim_ntuple_2018_marina.cfg
+++ b/analysis/sixBanalysis/config/skim_ntuple_2018_marina.cfg
@@ -77,7 +77,6 @@ bTagWP    = 1  # Which WP to apply for the selection above. 0 : Loose, 1: Medium
 
 ## -------------------------------------------------------------------------
 ## configuration of the various function-specific parameters
-
 [presel]
 apply = true
 pt_min  = 20
@@ -87,11 +86,10 @@ pu_id   = 1
 njetsCutValue = 6
 njetsCutDirection = >=
 
-
 [bias_pt_sort]
 applyPreselections = true
 applyJetCuts = true ## apply extra jet cuts after preselection
-#pt_cuts = 60,40,40,20 # ,20,20 # pt cuts for jet selection
+pt_cuts = 60,40,40,20 
 btagWP_cuts = 2,2,1,1 # ,0,0 # btagWP cuts for jet selection
 
 [6jet_DNN]
@@ -112,7 +110,7 @@ applyTrigger = true # true/false to apply/not apply trigger bit
 saveDecision = true # true to create branches with individual trigger decisions
 
 #Trigger Matching
-makeORof = trigger1:HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5, trigger2:HLT_PFHT1050, trigger3:HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59, trigger4:HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94
+makeORof = trigger1:HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5
 
 # MaxDeltaR                   = 0.5
 # trigger1_ObjectRequirements = 1:10:0, 1:5:4, 3:3:0, 1:11:2, 1:12:4, 1:13:1, 1:14:2, 1:15:3, 1:16:4, 3:4:0, 1:17:3

--- a/analysis/sixBanalysis/interface/Electron.h
+++ b/analysis/sixBanalysis/interface/Electron.h
@@ -15,6 +15,19 @@ public:
     return std::unique_ptr<Electron> (clonedElectron);
   }
 
+  float get_E() const { return this->P4().E(); }
+  float get_m() const { return this->P4().M(); }
+  float get_pt() const { return this->P4().Pt(); }
+  float get_eta() const { return this->P4().Eta(); }
+  float get_phi() const { return this->P4().Phi(); }
+  float get_dxy() const { return get_property((*this), Electron_dxy); }
+  float get_dz() const { return get_property((*this), Electron_dz); }
+  float get_charge() const { return get_property((*this), Electron_charge); }
+  float get_pfRelIso03_all() const { return get_property((*this), Electron_pfRelIso03_all); }
+  bool get_mvaFall17V2Iso_WPL() const { return get_property((*this), Electron_mvaFall17V2Iso_WPL); }
+  bool get_mvaFall17V2Iso_WP90() const { return get_property((*this), Electron_mvaFall17V2Iso_WP90); }
+  bool get_mvaFall17V2Iso_WP80() const { return get_property((*this), Electron_mvaFall17V2Iso_WP80); }
+  
 private:
   void buildP4() override; 
 };

--- a/analysis/sixBanalysis/interface/EventInfo.h
+++ b/analysis/sixBanalysis/interface/EventInfo.h
@@ -38,6 +38,9 @@ struct EventInfo{
   boost::optional<int>    n_genjet;
   boost::optional<int>    n_higgs;
 
+  boost::optional<int>    n_ele;
+  boost::optional<int>    n_muon;
+  
   boost::optional<float>  b_6j_score;
   boost::optional<float>  b_3d_score;
 
@@ -185,7 +188,8 @@ struct EventInfo{
   boost::optional<float> quadh_score;
   
   // End Reco 8B Objects
-
+  boost::optional< std::vector<Electron> > ele_list;
+  boost::optional< std::vector<Muon> > muon_list;
   boost::optional< std::vector<GenJet> > genjet_list;
   boost::optional< std::vector<Jet> > jet_list;
   boost::optional<std::vector<DiJet>> dijet_list;
@@ -205,16 +209,6 @@ struct EventInfo{
   // for ttbar skims
   boost::optional<Jet> bjet1;
   boost::optional<Jet> bjet2;
-
-  // info on leptons in the event
-  boost::optional<Muon> mu_1;
-  boost::optional<Muon> mu_2;
-  boost::optional<Electron> ele_1;
-  boost::optional<Electron> ele_2;
-  boost::optional<int> n_mu_loose;
-  boost::optional<int> n_ele_loose;
-  // boost::optional<int> n_mu_tight;
-  // boost::optional<int> n_ele_tight;
 
   // scale factors
   boost::optional<double> btagSF_WP_M;

--- a/analysis/sixBanalysis/interface/Muon.h
+++ b/analysis/sixBanalysis/interface/Muon.h
@@ -14,6 +14,20 @@ public:
     clonedMuon->setP4(this->P4());
     return std::unique_ptr<Muon> (clonedMuon);
   }
+
+  float get_E() const { return this->P4().E(); }
+  float get_m() const { return this->P4().M(); }
+  float get_pt() const { return this->P4().Pt(); }
+  float get_eta() const { return this->P4().Eta(); }
+  float get_phi() const { return this->P4().Phi(); }
+  float get_dxy() const { return get_property((*this), Muon_dxy); }
+  float get_dz() const { return get_property((*this), Muon_dz); }
+  float get_charge() const { return get_property((*this), Muon_charge); }
+  float get_pfRelIso04_all() const { return get_property((*this), Muon_pfRelIso04_all); }
+  bool get_looseId() const { return get_property((*this), Muon_looseId); }
+  bool get_mediumId() const { return get_property((*this), Muon_mediumId); }
+  bool get_tightId() const { return get_property((*this), Muon_tightId); }
+  
 private:
   void buildP4() override; 
 };

--- a/analysis/sixBanalysis/interface/OutputTree.h
+++ b/analysis/sixBanalysis/interface/OutputTree.h
@@ -79,6 +79,34 @@ typedef ROOT::Math::PtEtaPhiMVector p4_t;
   float OBJ##_score;                                           \
   p4_t OBJ##_p4;
 
+#define DECLARE_ele_list(OBJ)               \
+  std::vector<float> OBJ##_E;               \
+  std::vector<float> OBJ##_m;               \
+  std::vector<float> OBJ##_pt;              \
+  std::vector<float> OBJ##_eta;             \
+  std::vector<float> OBJ##_phi;             \
+  std::vector<float> OBJ##_dxy;             \
+  std::vector<float> OBJ##_dz;              \
+  std::vector<float> OBJ##_charge;          \
+  std::vector<float> OBJ##_pfRelIso03_all;     \
+  std::vector<bool> OBJ##_mvaFall17V2Iso_WPL;  \
+  std::vector<bool> OBJ##_mvaFall17V2Iso_WP90; \
+  std::vector<bool> OBJ##_mvaFall17V2Iso_WP80;
+
+#define DECLARE_muon_list(OBJ)             \
+  std::vector<float> OBJ##_E;              \
+  std::vector<float> OBJ##_m;              \
+  std::vector<float> OBJ##_pt;             \
+  std::vector<float> OBJ##_eta;            \
+  std::vector<float> OBJ##_phi;            \
+  std::vector<float> OBJ##_dxy;            \
+  std::vector<float> OBJ##_dz;             \
+  std::vector<float> OBJ##_charge;         \
+  std::vector<float> OBJ##_pfRelIso04_all; \
+  std::vector<bool> OBJ##_looseId;         \
+  std::vector<bool> OBJ##_mediumId;        \
+  std::vector<bool> OBJ##_tightId;
+
 #define DECLARE_jet_list(OBJ)           \
   std::vector<float> OBJ##_E;           \
   std::vector<float> OBJ##_m;           \
@@ -155,6 +183,9 @@ public:
   int n_jet;
   int n_higgs;
 
+  int n_ele;
+  int n_muon;
+  
   float b_6j_score;
   float b_3d_score;
 
@@ -167,7 +198,9 @@ public:
   std::vector<int> genjet_hadronFlav;
   std::vector<int> genjet_signalId;
   std::vector<int> genjet_recoIdx;
-
+  
+  DECLARE_ele_list(ele);
+  DECLARE_muon_list(muon);
   DECLARE_jet_list(jet);
 
   int n_dijet;
@@ -322,14 +355,6 @@ public:
   int nfound_paired_h;
   int nfound_select_y;
   int nfound_paired_y;
-
-  DECLARE_m_pt_eta_phi_p4(mu_1);
-  DECLARE_m_pt_eta_phi_p4(mu_2);
-  DECLARE_m_pt_eta_phi_p4(ele_1);
-  DECLARE_m_pt_eta_phi_p4(ele_2);
-
-  int n_mu_loose;
-  int n_ele_loose;
 
   DECLARE_m_pt_ptRegressed_eta_phi_DeepJet_p4(bjet1);
   int bjet1_hadflav;

--- a/analysis/sixBanalysis/interface/Skim_functions.h
+++ b/analysis/sixBanalysis/interface/Skim_functions.h
@@ -64,7 +64,7 @@ public:
   std::vector<Jet> get_all_jets(NanoAODTree &nat);
 
   // create a vector with all preselected jets in the event (minimal pt/eta/id requirements)
-  std::vector<Jet> preselect_jets(NanoAODTree &nat, const std::vector<Jet> &in_jets);
+  std::vector<Jet> preselect_jets(NanoAODTree &nat, EventInfo& ei, const std::vector<Jet> &in_jets);
 
   std::vector<Jet> btag_sort_jets(NanoAODTree &nat, EventInfo& ei, const std::vector<Jet> &in_jets);
 

--- a/analysis/sixBanalysis/plotter/modules/Samples_NMSSM_XYH_YToHH_6b.py
+++ b/analysis/sixBanalysis/plotter/modules/Samples_NMSSM_XYH_YToHH_6b.py
@@ -1,0 +1,269 @@
+import os
+import modules.Sample as sam
+from modules.XSections import bkgXSectionList as xs
+
+# This needs to be calculated. No hardcoded lumi.
+lumiMap = {}
+lumiMap["2018A"] = {"lumi": 14030, "lumi_units" : "pbinv"}
+lumiMap["2018B"] = {"lumi": 7070,  "lumi_units" : "pbinv"}
+lumiMap["2018C"] = {"lumi": 6900,  "lumi_units" : "pbinv"}
+lumiMap["2018D"] = {"lumi": 31750, "lumi_units" : "pbinv"}
+lumiMap["2018" ] = {'lumi' : 59.740, 'lumi_units' : 'fbinv'}
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+#                      DEFINITIONS
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+version    = ""
+energy     = "13" # TeV
+redirector = "root://cmsxrootd.fnal.gov/"
+
+directories = {}
+directories["2016"] = ''
+directories["2017"] = ''
+directories["2018"] = '/store/user/mkolosov/HHHTo6B/Summer2018UL_29Sep2022_withoutLeptonVeto/'
+
+path = {}
+path["2016"] = ""
+path["2017"] = ""
+path["2018"] = "".join([redirector, directories["2018"]])
+
+JetHT_Run2018A = sam.Sample(name = "Data", sampletype="data", files=[path["2018"]+'/JetHT_Run2018A/ntuple.root'], sampledesc={**lumiMap["2018A"]})
+JetHT_Run2018B = sam.Sample(name = "Data", sampletype="data", files=[path["2018"]+'/JetHT_Run2018B/ntuple.root'], sampledesc={**lumiMap["2018B"]})
+JetHT_Run2018C = sam.Sample(name = "Data", sampletype="data", files=[path["2018"]+'/JetHT_Run2018C/ntuple.root'], sampledesc={**lumiMap["2018C"]})
+JetHT_Run2018D = sam.Sample(name = "Data", sampletype="data", files=[path["2018"]+'/JetHT_Run2018D/ntuple.root'], sampledesc={**lumiMap["2018D"]})
+
+NMSSM_XYH_YToHH_6b_MX_450_MY_300 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_450_MY_300",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_450_MY_300_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_500_MY_300 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_500_MY_300",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_500_MY_300_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_600_MY_300 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_600_MY_300",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_600_MY_300_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_600_MY_400 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_600_MY_400",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_600_MY_400_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_700_MY_300 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_700_MY_300",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_700_MY_300_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_700_MY_400 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_700_MY_400",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_700_MY_400_sl7_nano_2M/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_700_MY_500 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_700_MY_500",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_700_MY_500_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_800_MY_300 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_800_MY_300",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_800_MY_300_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_800_MY_400 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_800_MY_400",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_800_MY_400_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_800_MY_500 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_800_MY_500",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_800_MY_500_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_800_MY_600 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_800_MY_600",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_800_MY_600_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_900_MY_300 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_900_MY_300",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_900_MY_300_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_900_MY_400 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_900_MY_400",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_900_MY_400_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_900_MY_500 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_900_MY_500",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_900_MY_500_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_900_MY_600 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_900_MY_600",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_900_MY_600_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_900_MY_700 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_900_MY_700",
+                                              sampletype = "mc",
+                                              files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_900_MY_700_sl7_nano_100k/ntuple.root'],
+                                              sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1000_MY_300 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1000_MY_300",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1000_MY_300_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1000_MY_400 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1000_MY_400",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1000_MY_400_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1000_MY_500 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1000_MY_500",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1000_MY_500_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1000_MY_600 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1000_MY_600",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1000_MY_600_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1000_MY_700 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1000_MY_700",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1000_MY_700_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1000_MY_800 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1000_MY_800",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1000_MY_800_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1100_MY_300 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1100_MY_300",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1100_MY_300_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1100_MY_400 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1100_MY_400",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1100_MY_400_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1100_MY_500 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1100_MY_500",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1100_MY_500_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1100_MY_600 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1100_MY_600",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1100_MY_600_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1100_MY_700 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1100_MY_700",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1100_MY_700_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1100_MY_800 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1100_MY_800",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1100_MY_800_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1100_MY_900 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1100_MY_900",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1100_MY_900_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1200_MY_300 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1200_MY_300",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1200_MY_300_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1200_MY_400 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1200_MY_400",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1200_MY_400_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1200_MY_500 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1200_MY_500",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1200_MY_500_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1200_MY_600 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1200_MY_600",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1200_MY_600_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1200_MY_700 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1200_MY_700",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1200_MY_700_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1200_MY_800 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1200_MY_800",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1200_MY_800_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+NMSSM_XYH_YToHH_6b_MX_1200_MY_900 = sam.Sample(name       = "NMSSM_XYH_YToHH_6b_MX_1200_MY_900",
+                                               sampletype = "mc",
+                                               files      = [path["2018"]+'srosenzw_NMSSM_XYH_YToHH_6b_MX_1200_MY_900_sl7_nano_100k/ntuple.root'],
+                                               sampledesc = {**lumiMap["2018"], 'xs' : 0.3, 'xs_units' : 'pb'})
+
+TTJets = sam.Sample(name       = "TTJets",
+                    sampletype = "mc",
+                    files      = [path["2018"]+'TTJets/ntuple.root'],
+                    sampledesc = {**lumiMap["2018"], 'xs' : xs.get("TTJets", energy), 'xs_units' : 'pb'})
+
+QCD_bEnriched_HT100to200 = sam.Sample(name       = "QCD",
+                                      sampletype = "mc",
+                                      files      = [path["2018"]+'QCD_bEnriched_HT100to200_TuneCP5_13TeV-madgraph-pythia8/ntuple.root'],
+                                      sampledesc = {**lumiMap["2018"], 'xs': xs.get("QCD_bEnriched_HT100to200", energy), 'xs_units':'pb'})
+QCD_bEnriched_HT200to300 = sam.Sample(name       = "QCD",
+                                      sampletype = "mc",
+                                      files   = [path["2018"]+'QCD_bEnriched_HT200to300_TuneCP5_13TeV-madgraph-pythia8/ntuple.root'],
+                                      sampledesc = {**lumiMap["2018"], 'xs': xs.get("QCD_bEnriched_HT200to300", energy), 'xs_units':'pb'})
+QCD_bEnriched_HT300to500 = sam.Sample(name       = "QCD",
+                                      sampletype = "mc",
+                                      files   = [path["2018"]+'QCD_bEnriched_HT300to500_TuneCP5_13TeV-madgraph-pythia8/ntuple.root'],
+                                      sampledesc = {**lumiMap["2018"], 'xs': xs.get("QCD_bEnriched_HT300to500", energy), 'xs_units':'pb'})
+QCD_bEnriched_HT500to700 = sam.Sample(name       = "QCD",
+                                      sampletype = "mc",
+                                      files = [path["2018"]+'QCD_bEnriched_HT500to700_TuneCP5_13TeV-madgraph-pythia8/ntuple.root'],
+                                      sampledesc = {**lumiMap["2018"], 'xs': xs.get("QCD_bEnriched_HT500to700", energy), 'xs_units':'pb'})
+QCD_bEnriched_HT700to1000 = sam.Sample(name        = "QCD",
+                                       sampletype  = "mc",
+                                       files       = [path["2018"]+'QCD_bEnriched_HT700to1000_TuneCP5_13TeV-madgraph-pythia8/ntuple.root'],
+                                       sampledesc  = {**lumiMap["2018"], 'xs': xs.get("QCD_bEnriched_HT700to1000", energy), 'xs_units':'pb'})
+QCD_bEnriched_HT1000to1500 = sam.Sample(name       = "QCD",
+                                        sampletype = "mc",
+                                        files      = [path["2018"]+'QCD_bEnriched_HT1000to1500_TuneCP5_13TeV-madgraph-pythia8/ntuple.root'],
+                                        sampledesc = {**lumiMap["2018"], 'xs': xs.get("QCD_bEnriched_HT1000to1500", energy), 'xs_units':'pb'})
+QCD_bEnriched_HT1500to2000 = sam.Sample(name       = "QCD",
+                                        sampletype = "mc",
+                                        files      = [path["2018"]+'QCD_bEnriched_HT1500to2000_TuneCP5_13TeV-madgraph-pythia8/ntuple.root'],
+                                        sampledesc = {**lumiMap["2018"], 'xs': xs.get("QCD_bEnriched_HT1500to2000", energy), 'xs_units':'pb'})
+QCD_bEnriched_HT2000toInf = sam.Sample(name        = "QCD",
+                                       sampletype  = "mc",
+                                       files       = [path["2018"]+'QCD_bEnriched_HT2000toInf_TuneCP5_13TeV-madgraph-pythia8/ntuple.root'],
+                                       sampledesc = {**lumiMap["2018"], 'xs': xs.get("QCD_bEnriched_HT2000toInf", energy), 'xs_units':'pb'})
+
+dsetGroups = {}
+dsetGroups["NMSSM_XYH_YToHH_6b"] = {"2018" : [], "2017" : [], "2016" : []}
+dsetGroups["Data"]               = {"2018" : [], "2017" : [], "2016" : []}
+dsetGroups["TT"]                 = {"2018" : [], "2017" : [], "2016" : []}
+dsetGroups["QCD"]                = {"2018" : [], "2017" : [], "2016" : []}
+
+# 2018 Samples:
+dsetGroups["NMSSM_XYH_YToHH_6b"]["2018"] = [NMSSM_XYH_YToHH_6b_MX_450_MY_300,
+                                            NMSSM_XYH_YToHH_6b_MX_500_MY_300,
+                                            NMSSM_XYH_YToHH_6b_MX_600_MY_300,
+                                            NMSSM_XYH_YToHH_6b_MX_600_MY_400,
+                                            NMSSM_XYH_YToHH_6b_MX_700_MY_300,
+                                            NMSSM_XYH_YToHH_6b_MX_700_MY_400,
+                                            NMSSM_XYH_YToHH_6b_MX_700_MY_500,
+                                            NMSSM_XYH_YToHH_6b_MX_800_MY_300,
+                                            NMSSM_XYH_YToHH_6b_MX_800_MY_400,
+                                            NMSSM_XYH_YToHH_6b_MX_800_MY_500,
+                                            NMSSM_XYH_YToHH_6b_MX_800_MY_600,
+                                            NMSSM_XYH_YToHH_6b_MX_900_MY_300,
+                                            NMSSM_XYH_YToHH_6b_MX_900_MY_400,
+                                            NMSSM_XYH_YToHH_6b_MX_900_MY_500,
+                                            NMSSM_XYH_YToHH_6b_MX_900_MY_600,
+                                            NMSSM_XYH_YToHH_6b_MX_900_MY_700,
+                                            NMSSM_XYH_YToHH_6b_MX_1000_MY_300,
+                                            NMSSM_XYH_YToHH_6b_MX_1000_MY_400,
+                                            NMSSM_XYH_YToHH_6b_MX_1000_MY_500,
+                                            NMSSM_XYH_YToHH_6b_MX_1000_MY_600,
+                                            NMSSM_XYH_YToHH_6b_MX_1000_MY_700,
+                                            NMSSM_XYH_YToHH_6b_MX_1100_MY_800,
+                                            NMSSM_XYH_YToHH_6b_MX_1100_MY_900,
+                                            NMSSM_XYH_YToHH_6b_MX_1200_MY_300,
+                                            NMSSM_XYH_YToHH_6b_MX_1200_MY_400,
+                                            NMSSM_XYH_YToHH_6b_MX_1200_MY_500,
+                                            NMSSM_XYH_YToHH_6b_MX_1200_MY_600,
+                                            NMSSM_XYH_YToHH_6b_MX_1200_MY_700,
+                                            NMSSM_XYH_YToHH_6b_MX_1200_MY_800,
+                                            NMSSM_XYH_YToHH_6b_MX_1200_MY_900]
+
+dsetGroups["TT"]["2018"] = [TTJets]
+dsetGroups["QCD"]["2018"] = [QCD_bEnriched_HT100to200,
+                             QCD_bEnriched_HT200to300,
+                             QCD_bEnriched_HT300to500,
+                             QCD_bEnriched_HT500to700,
+                             QCD_bEnriched_HT700to1000,
+                             QCD_bEnriched_HT1000to1500,
+                             QCD_bEnriched_HT1500to2000,
+                             QCD_bEnriched_HT2000toInf]
+dsetGroups["Data"]["2018"] = [JetHT_Run2018A,
+                              JetHT_Run2018B,
+                              JetHT_Run2018C,
+                              JetHT_Run2018D]
+

--- a/analysis/sixBanalysis/plotter/modules/XSections.py
+++ b/analysis/sixBanalysis/plotter/modules/XSections.py
@@ -1,0 +1,64 @@
+'''
+DESCRIPTION:
+
+Cross-section (in pb) of all samples used in multi-b analyses as a function of the energy (TeV)
+
+Sources:
+ [1] https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV
+ [2] https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG
+'''
+class CrossSection:
+    def __init__(self, name, energyDict):
+        self.name = name
+        for key, value in energyDict.items():
+            setattr(self, key, value)
+        return
+        
+    def get(self, energy):
+        '''
+        Return the cross-section based on the energy (TeV)
+        '''
+        print("\n XSection of %s is %s" % (self.name, getattr(self, energy)))
+        try:
+            return getattr(self, energy)
+        except AttributeError:
+            print("No cross section for energy %s TeV." % (energy))
+
+class CrossSectionList:
+    def __init__(self, *args):
+        self.crossSections = args[:]
+        
+    def get(self, name, energy):
+        for obj in self.crossSections:
+            if name == obj.name:
+                return obj.get(energy)
+
+bkgXSectionList = CrossSectionList(
+    CrossSection("TTJets", {"13": 831.76,}),
+    CrossSection("TT",     {"13": 831.76,}),
+    CrossSection("TTToHadronic", {"13": 831.76*0.6741*0.6741,}),       # 377.96 pb
+    CrossSection("TTTo2L2Nu",    {"13": 831.76*0.3259*0.3259,}),       # 88.34 pb
+    CrossSection("TTToSemiLeptonic", {"13": 831.76*2*0.6741*0.3259,}), # 365.45 pb
+    # QCD b-Enriched
+    CrossSection("QCD_bEnriched_HT100to200",   {"13": 1127000.0, }),
+    CrossSection("QCD_bEnriched_HT200to300",   {"13": 80430.0,   }),
+    CrossSection("QCD_bEnriched_HT300to500",   {"13": 16620.0,   }),
+    CrossSection("QCD_bEnriched_HT500to700",   {"13": 1487.0,    }),
+    CrossSection("QCD_bEnriched_HT700to1000",  {"13": 296.5,     }),
+    CrossSection("QCD_bEnriched_HT1000to1500", {"13": 46.61,     }),
+    CrossSection("QCD_bEnriched_HT1500to2000", {"13": 3.72,      }),
+    CrossSection("QCD_bEnriched_HT2000toInf",  {"13": 0.6462,    }),
+    # QCD mu-Enriched
+    CrossSection("QCD_Pt_15to20_MuEnrichedPt5",   {"13": 3.625e+06, }),
+    CrossSection("QCD_Pt_20to30_MuEnrichedPt5",   {"13": 3.153e+06, }),
+    CrossSection("QCD_Pt_30to50_MuEnrichedPt5",   {"13": 1.652e+06, }),
+    CrossSection("QCD_Pt_50to80_MuEnrichedPt5",   {"13": 4.488e+05, }),
+    CrossSection("QCD_Pt_80to120_MuEnrichedPt5",  {"13": 1.052e+05, }),
+    CrossSection("QCD_Pt_120to170_MuEnrichedPt5", {"13": 2.549e+04, }),
+    CrossSection("QCD_Pt_170to300_MuEnrichedPt5", {"13": 8.639e+03, }),
+    CrossSection("QCD_Pt_300to470_MuEnrichedPt5", {"13": 7.961e+02, }),
+    CrossSection("QCD_Pt_470to600_MuEnrichedPt5", {"13": 7.920e+01, }),
+    CrossSection("QCD_Pt_600to800_MuEnrichedPt5", {"13": 2.525e+01, }),
+    CrossSection("QCD_Pt_800to1000_MuEnrichedPt5", {"13": 4.724e+00, }),
+    CrossSection("QCD_Pt_1000toInf_MuEnrichedPt5", {"13": 1.619e+00, }),
+)

--- a/analysis/sixBanalysis/src/EightB_functions.cc
+++ b/analysis/sixBanalysis/src/EightB_functions.cc
@@ -28,7 +28,7 @@ void EightB_functions::initialize_params_from_cfg(CfgParser& config)
 
   // preselections
   pmap.insert_param<bool>("presel","apply", config.readBoolOpt("presel::apply"));
-  pmap.insert_param<double>("presel", "pt_min",  config.readDoubleOpt("presel::pt_min"));
+  pmap.insert_param<std::vector<double> >("presel", "pt_min", config.readDoubleListOpt("presel::pt_min"));
   pmap.insert_param<double>("presel", "eta_max", config.readDoubleOpt("presel::eta_max"));
   pmap.insert_param<int>   ("presel", "pf_id",   config.readIntOpt("presel::pf_id"));
   pmap.insert_param<int>   ("presel", "pu_id",   config.readIntOpt("presel::pu_id"));

--- a/analysis/sixBanalysis/src/OutputTree.cc
+++ b/analysis/sixBanalysis/src/OutputTree.cc
@@ -102,6 +102,63 @@ using namespace std;
   OBJ##_score = -999.;                                       \
   OBJ##_p4.SetCoordinates(0, 0, 0, 0);
 
+#define BRANCH_ele_list(OBJ)                                    \
+  tree_->Branch(#OBJ "_E", &OBJ##_E);                           \
+  tree_->Branch(#OBJ "_m", &OBJ##_m);                           \
+  tree_->Branch(#OBJ "_pt", &OBJ##_pt);                         \
+  tree_->Branch(#OBJ "_eta", &OBJ##_eta);                       \
+  tree_->Branch(#OBJ "_phi", &OBJ##_phi);                       \
+  tree_->Branch(#OBJ "_dxy", &OBJ##_dxy);                       \
+  tree_->Branch(#OBJ "_dz",  &OBJ##_dz);                        \
+  tree_->Branch(#OBJ "_charge", &OBJ##_charge);                 \
+  tree_->Branch(#OBJ "_pfRelIso03_all", &OBJ##_pfRelIso03_all);           \
+  tree_->Branch(#OBJ "_mvaFall17V2Iso_WPL", &OBJ##_mvaFall17V2Iso_WPL);   \
+  tree_->Branch(#OBJ "_mvaFall17V2Iso_WP90", &OBJ##_mvaFall17V2Iso_WP90); \
+  tree_->Branch(#OBJ "_mvaFall17V2Iso_WP80", &OBJ##_mvaFall17V2Iso_WP80); 
+
+#define BRANCH_muon_list(OBJ)                                   \
+  tree_->Branch(#OBJ "_E", &OBJ##_E);                           \
+  tree_->Branch(#OBJ "_m", &OBJ##_m);                           \
+  tree_->Branch(#OBJ "_pt", &OBJ##_pt);                         \
+  tree_->Branch(#OBJ "_eta", &OBJ##_eta);                       \
+  tree_->Branch(#OBJ "_phi", &OBJ##_phi);                       \
+  tree_->Branch(#OBJ "_dxy", &OBJ##_dxy);                       \
+  tree_->Branch(#OBJ "_dz",  &OBJ##_dz);                        \
+  tree_->Branch(#OBJ "_charge", &OBJ##_charge);                 \
+  tree_->Branch(#OBJ "_pfRelIso04_all", &OBJ##_pfRelIso04_all); \
+  tree_->Branch(#OBJ "_isLoose", &OBJ##_looseId);               \
+  tree_->Branch(#OBJ "_isMedium", &OBJ##_mediumId);             \
+  tree_->Branch(#OBJ "_isTight", &OBJ##_tightId);
+
+#define CLEAR_ele_list(OBJ)     \
+  OBJ##_E.clear();              \
+  OBJ##_m.clear();              \
+  OBJ##_pt.clear();             \
+  OBJ##_eta.clear();            \
+  OBJ##_phi.clear();            \
+  OBJ##_dxy.clear();            \
+  OBJ##_dz.clear();             \
+  OBJ##_charge.clear();         \
+  OBJ##_pfRelIso03_all.clear(); \
+  OBJ##_mvaFall17V2Iso_WPL.clear();  \
+  OBJ##_mvaFall17V2Iso_WP90.clear(); \
+  OBJ##_mvaFall17V2Iso_WP80.clear();
+
+#define CLEAR_muon_list(OBJ)    \
+  OBJ##_E.clear();              \
+  OBJ##_m.clear();		\
+  OBJ##_pt.clear();             \
+  OBJ##_eta.clear();            \
+  OBJ##_phi.clear();            \
+  OBJ##_dxy.clear();            \
+  OBJ##_dz.clear();             \
+  OBJ##_charge.clear();         \
+  OBJ##_pfRelIso04_all.clear(); \
+  OBJ##_looseId.clear();        \
+  OBJ##_mediumId.clear();       \
+  OBJ##_tightId.clear();
+  
+
 #define BRANCH_jet_list(OBJ)                                  \
   tree_->Branch(#OBJ "_E", &OBJ##_E);                         \
   tree_->Branch(#OBJ "_m", &OBJ##_m);                         \
@@ -348,19 +405,21 @@ void OutputTree::init_branches(std::map<std::string, bool> branch_switches)
 
     tree_->Branch("quadh_score", &quadh_score);
   }
-
-  tree_->Branch("n_mu_loose",  &n_mu_loose);
-  tree_->Branch("n_ele_loose", &n_ele_loose);
-    
-  if (is_enabled("leptons_p4"))
+  
+  tree_->Branch("n_muon", &n_muon);
+  if (is_enabled("muon_coll"))
     {
-      std::cout << "[INFO] OutputTree : enabling lepton p4 branches" << std::endl;
-      BRANCH_m_pt_eta_phi_p4(mu_1);
-      BRANCH_m_pt_eta_phi_p4(mu_2);
-      BRANCH_m_pt_eta_phi_p4(ele_1);
-      BRANCH_m_pt_eta_phi_p4(ele_2);
+      std::cout << "[INFO] OutputTree : enabling muon collection branches" << std::endl;
+      BRANCH_muon_list(muon);
     }
-
+  
+  tree_->Branch("n_ele", &n_ele);
+  if (is_enabled("ele_coll"))
+    {
+      std::cout << "[INFO] OutputTree : enabling electron collection branches" << std::endl;
+      BRANCH_ele_list(ele);
+    }
+  
   if (is_enabled("ttbar_brs"))
     {
       std::cout << "[INFO] OutputTree : enabling ttbar branches" << std::endl;
@@ -458,6 +517,9 @@ void OutputTree::clear()
   n_genjet = 0;
   n_higgs = 0;
 
+  n_ele = 0;
+  n_muon = 0;
+  
   b_6j_score = 0;
   b_3d_score = 0;
   quadh_score = 0;
@@ -472,6 +534,8 @@ void OutputTree::clear()
   genjet_signalId.clear();
   genjet_recoIdx.clear();
 
+  CLEAR_ele_list(ele);
+  CLEAR_muon_list(muon);
   CLEAR_jet_list(jet);
 
   n_dijet = 0;
@@ -612,14 +676,6 @@ void OutputTree::clear()
   n_tight_btag = -1;
   btagavg = -1.;
   // End Reco 8B Objects
-
-  CLEAR_m_pt_eta_phi_p4(mu_1);
-  CLEAR_m_pt_eta_phi_p4(mu_2);
-  CLEAR_m_pt_eta_phi_p4(ele_1);
-  CLEAR_m_pt_eta_phi_p4(ele_2);
-
-  n_mu_loose  = 0;
-  n_ele_loose = 0;
 
   CLEAR_m_pt_ptRegressed_eta_phi_DeepJet_p4(bjet1);
   CLEAR_m_pt_ptRegressed_eta_phi_DeepJet_p4(bjet2);

--- a/analysis/sixBanalysis/src/SkimUtils.cc
+++ b/analysis/sixBanalysis/src/SkimUtils.cc
@@ -88,6 +88,42 @@ using namespace std;
     ot.OBJ##_p4 = ei.OBJ->P4();                                      \
   }
 
+#define COPY_OPTIONAL_ele_list(OBJ)                                  \
+  if (ei.OBJ##_list) {                                               \
+      for (Electron & ele : ei.OBJ##_list.get()) {		     \
+        ot.OBJ##_E.push_back(ele.get_E());                          \
+	ot.OBJ##_m.push_back(ele.get_m());			     \
+	ot.OBJ##_pt.push_back(ele.get_pt());			     \
+        ot.OBJ##_eta.push_back(ele.get_eta());                       \
+        ot.OBJ##_phi.push_back(ele.get_phi());                       \
+        ot.OBJ##_dxy.push_back(ele.get_dxy());                       \
+        ot.OBJ##_dz.push_back(ele.get_dz());                         \
+        ot.OBJ##_charge.push_back(ele.get_charge());                 \
+        ot.OBJ##_pfRelIso03_all.push_back(ele.get_pfRelIso03_all());            \
+        ot.OBJ##_mvaFall17V2Iso_WPL.push_back(ele.get_mvaFall17V2Iso_WPL());    \
+        ot.OBJ##_mvaFall17V2Iso_WP90.push_back(ele.get_mvaFall17V2Iso_WP90());  \
+        ot.OBJ##_mvaFall17V2Iso_WP80.push_back(ele.get_mvaFall17V2Iso_WP80());  \
+      }								        	\
+  }
+
+#define COPY_OPTIONAL_muon_list(OBJ)                                \
+  if (ei.OBJ##_list) {                                              \
+    for (Muon & muon : ei.OBJ##_list.get()) {			    \
+      ot.OBJ##_E.push_back(muon.get_E());                           \
+      ot.OBJ##_m.push_back(muon.get_m());		            \
+      ot.OBJ##_pt.push_back(muon.get_pt());	                    \
+      ot.OBJ##_eta.push_back(muon.get_eta());		            \
+      ot.OBJ##_phi.push_back(muon.get_phi());			    \
+      ot.OBJ##_dxy.push_back(muon.get_dxy());			    \
+      ot.OBJ##_dz.push_back(muon.get_dz());			    \
+      ot.OBJ##_charge.push_back(muon.get_charge());	            \
+      ot.OBJ##_pfRelIso04_all.push_back(muon.get_pfRelIso04_all()); \
+      ot.OBJ##_looseId.push_back(muon.get_looseId());		    \
+      ot.OBJ##_mediumId.push_back(muon.get_mediumId());             \
+      ot.OBJ##_tightId.push_back(muon.get_tightId());               \
+    }                                                               \
+}
+
 #define COPY_OPTIONAL_jet_list(OBJ)                              \
   if (ei.OBJ##_list) {                                           \
     for (Jet & jet : ei.OBJ##_list.get()) {                      \
@@ -170,10 +206,14 @@ void SkimUtils::fill_output_tree(OutputTree& ot, NanoAODTree& nat, EventInfo& ei
   if(ei.n_total_jet)    ot.n_total_jet     = *ei.n_total_jet;
   if(ei.n_genjet)       ot.n_genjet        = *ei.n_genjet;
   if(ei.n_higgs)        ot.n_higgs         = *ei.n_higgs;
-
+  if(ei.n_ele)          ot.n_ele           = *ei.n_ele;
+  if(ei.n_muon)         ot.n_muon          = *ei.n_muon;
+  
   if(ei.b_6j_score)     ot.b_6j_score      = *ei.b_6j_score;
   if(ei.b_3d_score)     ot.b_3d_score      = *ei.b_3d_score;
 
+  COPY_OPTIONAL_ele_list(ele);
+  COPY_OPTIONAL_muon_list(muon);
   COPY_OPTIONAL_jet_list(jet);
 
   if (ei.genjet_list) {
@@ -351,14 +391,6 @@ void SkimUtils::fill_output_tree(OutputTree& ot, NanoAODTree& nat, EventInfo& ei
   if (ei.nfound_paired_h) ot.nfound_paired_h = *ei.nfound_paired_h;
   if (ei.nfound_select_y) ot.nfound_select_y = *ei.nfound_select_y;
   if (ei.nfound_paired_y) ot.nfound_paired_y = *ei.nfound_paired_y;
-
-  COPY_OPTIONAL_m_pt_eta_phi_p4(mu_1);
-  COPY_OPTIONAL_m_pt_eta_phi_p4(mu_2);
-  COPY_OPTIONAL_m_pt_eta_phi_p4(ele_1);
-  COPY_OPTIONAL_m_pt_eta_phi_p4(ele_2);
-
-  ot.n_mu_loose  = *ei.n_mu_loose;
-  ot.n_ele_loose = *ei.n_ele_loose;
 
   COPY_OPTIONAL_m_pt_ptRegressed_eta_phi_DeepJet_p4(bjet1);
   COPY_OPTIONAL_m_pt_ptRegressed_eta_phi_DeepJet_p4(bjet2);

--- a/analysis/sixBanalysis/src/TrgEff_functions.cc
+++ b/analysis/sixBanalysis/src/TrgEff_functions.cc
@@ -15,14 +15,13 @@ void TrgEff_functions::initialize_params_from_cfg(CfgParser& config)
 {
   // preselections
   pmap.insert_param<bool>("presel", "apply", config.readBoolOpt("presel::apply"));
-  pmap.insert_param<double>("presel", "pt_min",  config.readDoubleOpt("presel::pt_min"));
+  pmap.insert_param<std::vector<double> >("presel", "pt_min", config.readDoubleListOpt("presel::pt_min"));
   pmap.insert_param<double>("presel", "eta_max", config.readDoubleOpt("presel::eta_max"));
   pmap.insert_param<int>   ("presel", "pf_id",   config.readIntOpt("presel::pf_id"));
   pmap.insert_param<int>   ("presel", "pu_id",   config.readIntOpt("presel::pu_id"));
   
   // parse specific parameters for various functions
   pmap.insert_param<bool>          ("bias_pt_sort", "applyJetCuts", config.readBoolOpt("bias_pt_sort::applyJetCuts"));
-  pmap.insert_param<vector<double>>("bias_pt_sort", "pt_cuts",      config.readDoubleListOpt("bias_pt_sort::pt_cuts"));
   pmap.insert_param<vector<int>>   ("bias_pt_sort", "btagWP_cuts",  config.readIntListOpt("bias_pt_sort::btagWP_cuts"));
 }
 
@@ -39,18 +38,16 @@ std::vector<Jet> TrgEff_functions::select_jets_bias_pt_sort(NanoAODTree &nat, Ev
   if (apply_cuts)
     {
       bool pass_cuts = true;
-      std::vector<double> pt_cuts     = pmap.get_param<std::vector<double>>("bias_pt_sort", "pt_cuts");
       std::vector<int>    btagWP_cuts = pmap.get_param<std::vector<int>>("bias_pt_sort", "btagWP_cuts");
       
-      unsigned int ncuts = pt_cuts.size();
+      unsigned int ncuts = btagWP_cuts.size();
       
       for (unsigned int icut=0; icut<ncuts; icut++)
 	{
 	  const Jet& j = jets[icut];
-	  double ptCut = pt_cuts[icut];
 	  int  btagWP  = btagWP_cuts[icut];
 	  
-	  if (j.get_pt() <= ptCut || j.get_btag() <= btag_WPs[btagWP])
+	  if (j.get_btag() <= btag_WPs[btagWP])
 	    {
 	      pass_cuts = false;
 	      break;

--- a/analysis/sixBanalysis/src/TrgEff_functions.cc
+++ b/analysis/sixBanalysis/src/TrgEff_functions.cc
@@ -23,6 +23,7 @@ void TrgEff_functions::initialize_params_from_cfg(CfgParser& config)
   // parse specific parameters for various functions
   pmap.insert_param<bool>          ("bias_pt_sort", "applyJetCuts", config.readBoolOpt("bias_pt_sort::applyJetCuts"));
   pmap.insert_param<vector<int>>   ("bias_pt_sort", "btagWP_cuts",  config.readIntListOpt("bias_pt_sort::btagWP_cuts"));
+  pmap.insert_param<std::vector<double> >("bias_pt_sort", "pt_cuts", config.readDoubleListOpt("bias_pt_sort::pt_cuts"));
 }
 
 std::vector<Jet> TrgEff_functions::select_jets(NanoAODTree &nat, EventInfo& ei, const std::vector<Jet> &in_jets)

--- a/analysis/sixBanalysis/test/skim_ntuple.cpp
+++ b/analysis/sixBanalysis/test/skim_ntuple.cpp
@@ -325,11 +325,11 @@ int main(int argc, char** argv)
   TFile outputFile(outputFileName.c_str(), "recreate");
   OutputTree ot(opts["save-p4"].as<bool>(),
                 map<string, bool>{
-		// {"leptons_p4", config.readBoolOpt("configurations::saveLeptons")},
 		// {"jet_coll",   config.readBoolOpt("configurations::saveJetColl")},
 		// {"shape_brs",  config.readBoolOpt("configurations::saveShapes")},
-		{"leptons_p4",  readCfgOptWithDefault<bool>(config, "configurations::saveLeptons", false)},
-                {"jet_coll",    readCfgOptWithDefault<bool>(config, "configurations::saveJetColl", false)},
+		{"muon_coll",   readCfgOptWithDefault<bool>(config, "configurations::saveMuonColl", false)},
+		{"ele_coll",    readCfgOptWithDefault<bool>(config, "configurations::saveEleColl", false)},  
+		{"jet_coll",    readCfgOptWithDefault<bool>(config, "configurations::saveJetColl", false)},
 		{"shape_brs",   readCfgOptWithDefault<bool>(config, "configurations::saveShapes", false)},
 	        {"dijets_coll", readCfgOptWithDefault<bool>(config, "configurations::saveDiJets", false)},
 	        {"sixb_brs", (skim_type == ksixb)},
@@ -648,14 +648,14 @@ int main(int argc, char** argv)
     // Apply muon selection or veto
     //==================================
     std::vector<Muon> selected_muons = skf->select_muons(config, nat, ei);
-    ei.n_mu_loose = selected_muons.size();
-    
+    ei.n_muon    = selected_muons.size();
+    ei.muon_list = selected_muons;
+        
     bool applyMuonVeto = config.readBoolOpt("configurations::applyMuonVeto");
     bool applyMuonSelection = config.readBoolOpt("configurations::applyMuonSelection");
     if (applyMuonVeto)
       {
 	if (selected_muons.size() != 0) continue;
-	
 	cutflow.add("#mu veto", nwt);
 	loop_timer.click("#mu veto");
       }
@@ -663,10 +663,6 @@ int main(int argc, char** argv)
       {
 	const DirectionalCut<int> cfg_nMuons(config, "configurations::nMuonsCut");
 	if (!cfg_nMuons.passedCut(selected_muons.size())) continue;
-	
-	if (selected_muons.size() > 0) ei.mu_1 = selected_muons.at(0);
-	if (selected_muons.size() > 1) ei.mu_2 = selected_muons.at(1);
-	
 	cutflow.add("#mu selection", nwt);
 	loop_timer.click("#mu selection");
       }
@@ -675,21 +671,21 @@ int main(int argc, char** argv)
     // Apply electron selection or veto
     //=====================================
     std::vector<Electron> selected_electrons = skf->select_electrons(config, nat, ei);
-    ei.n_ele_loose = selected_electrons.size();
+    ei.n_ele    = selected_electrons.size();
+    ei.ele_list = selected_electrons;
     
     bool applyEleVeto = config.readBoolOpt("configurations::applyEleVeto");
     bool applyEleSelection = config.readBoolOpt("configurations::applyEleSelection");
     if (applyEleVeto)
       {
 	if (selected_electrons.size() !=0) continue;
-	
 	cutflow.add("e veto", nwt);
 	loop_timer.click("e veto");
       }
     else if (applyEleSelection)
       {
-	if (selected_electrons.size() > 0) ei.ele_1 = selected_electrons.at(0);
-	if (selected_electrons.size() > 1) ei.ele_2 = selected_electrons.at(1);
+	const DirectionalCut<int> cfg_nElectrons(config, "configurations::nEleCut");
+	if (!cfg_nElectrons.passedCut(selected_electrons.size())) continue;
 	cutflow.add("e selection", nwt);
 	loop_timer.click("e selection");
       }


### PR DESCRIPTION
Hi @ekoenig4, @srosenzweig09, 

I have updated the Skim_functions::preselect_jets to allow for different pT cuts on the jets. So, in your config file 
you can either have a single cut:

[presel]
pt_min = 20

or different cuts on the jets, for example:

[presel]
pt_min = 40, 40, 20

The last cut will be applied to all remaining jets, so make sure you write the minimum pT cut for all your preselected jets.

For the 6b analysis, I have moved the pT cuts on the b-jets after the 6 top b-jets are selected, and they are applied on pT sorted jets. The returning collection of jets is still the same (jets sorted by b-tagging score and then sorted by pT). 

Let me know if you have any questions or if something doesn’t work for you.

Marina